### PR TITLE
add MIT mention on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "author": "Darren DeRidder <drderidder@gmail.com> (https://github.com/darrenderidder)",
+  "license": "MIT",
   "name": "python",
   "main": "./lib/python.js",
   "description": "Interact with a long-running python child process",


### PR DESCRIPTION
since there is an MIT license mentioned on the README and Github rep, you should make a mention on npm as well.